### PR TITLE
Use `make-variable-like-transformer` from `syntax/transformer`

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -2,7 +2,7 @@
 
 (define collection 'multi)
 
-(define deps '("base"
+(define deps '(("base" #:version "6.2.900.6")
                "lens"
                "hash-lambda"
                "kw-utils"

--- a/my-object/stuff.rkt
+++ b/my-object/stuff.rkt
@@ -6,7 +6,7 @@
          racket/splicing
          (for-syntax racket/base
                      syntax/parse
-                     unstable/syntax
+                     syntax/transformer
                      ))
 
 (define-simple-macro (defrename [id1:id id2:id] ...)


### PR DESCRIPTION
That binding is provided by `syntax/transformer` as of 6.2.900.6, and `unstable/syntax` will be removed from the main distribution.

This PR makes this package incompatible with Racket 6.2. To preserve compatibility, you can create a Racket 6.2-compatible branch in this repository and set up a version exception at pkgs.racket-lang.org

Even without the changes from this PR, this package will continue to work with future versions of Racket. It will, however, require installation of the `unstable-lib` package, as it will not be part of the main distribution in future versions.
