### PR TITLE
Add dependency on unstable-lib

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -6,6 +6,7 @@
                "lens"
                "hash-lambda"
                "kw-utils"
+               "unstable-lib"
                ))
 
 (define build-deps '("rackunit-lib"


### PR DESCRIPTION
This should allow `my-object` to keep working after `unstable/syntax`, `unstable/sequence`, etc. are moved there.

IIUC, you prefer this solution to the "change requires + version exception branch" solution, correct? If that's the case, that's what I'll do for future pull requests as well. Does that sound reasonable?

Thanks!
